### PR TITLE
Fix case "define" - Webpack error

### DIFF
--- a/cells-by-row.js
+++ b/cells-by-row.js
@@ -12,7 +12,7 @@
   if ( typeof define === 'function' && define.amd ) {
     // AMD
     define( [
-        'isotope/js/layout-mode'
+        'isotope-layout/js/layout-mode'
       ],
       factory );
   } else if ( typeof exports === 'object' ) {


### PR DESCRIPTION
This fix an Webpack error:

Module not found: Error: Can't resolve 'isotope/js/layout-mode'